### PR TITLE
docs: document multi-arch contract metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ All capabilities follow a standardized interface defined in `capability.json`. T
   "resources": {
     "ram_mb": 6000,
     "cpu_cores": 4
-  }
+  },
+
+  "target_platforms": ["Raspberry Pi 4/5", "AMD64 (x86-64)"],
+  "supported_architectures": ["arm64", "amd64"],
+  "target_platform": "Raspberry Pi 4/5"
 }
 ```
 

--- a/docs/phase-2-architecture/capability-registry.md
+++ b/docs/phase-2-architecture/capability-registry.md
@@ -37,9 +37,19 @@ Each capability provides a `capability.json` that declares:
   "container": {
     "image": "docker.io/ollama/ollama",
     "port": 11434
-  }
+  },
+
+  // Optional metadata (informational)
+  // Prefer these for multi-target capabilities.
+  "target_platforms": ["Raspberry Pi 4/5", "AMD64 (x86-64)"],
+  "supported_architectures": ["arm64", "amd64"],
+
+  // Optional (deprecated): older single-target field, kept for backwards compatibility.
+  "target_platform": "Raspberry Pi 4/5"
 }
 ```
+
+The registry should treat `target_platform`, `target_platforms`, and `supported_architectures` as optional and non-blocking. These fields are useful for UI/selection and documentation, but discovery and routing should not depend on them.
 
 ### Discovery Method
 

--- a/docs/phase-2-architecture/resource-validator.md
+++ b/docs/phase-2-architecture/resource-validator.md
@@ -54,6 +54,8 @@ Each capability declares what it needs in `capability.json`:
 }
 ```
 
+Other optional contract fields (like `target_platform`, `target_platforms`, and `supported_architectures`) are treated as informational metadata and MUST NOT affect resource validation.
+
 ## Validation Logic
 
 ### Single Capability


### PR DESCRIPTION
## Summary
Updates platform-core documentation/examples to acknowledge optional multi-arch capability contract metadata.

## Changes
- Docs: show `target_platforms` + `supported_architectures` as optional fields
- Docs: clarify these fields are informational and MUST NOT affect resource validation
- README: update example capability contract accordingly

## Compatibility
- Keeps `target_platform` as deprecated-but-supported guidance.

## Checklist
- [x] Docs-only change
- [x] No behavior changes
